### PR TITLE
chore: Updated netty bundles to 4.1.127

### DIFF
--- a/bundles/org.eclipse.kura.driver.opcua.provider/pom.xml
+++ b/bundles/org.eclipse.kura.driver.opcua.provider/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <kura.basedir>${project.basedir}/..</kura.basedir>
         <com.google.guava.version>32.1.1-jre</com.google.guava.version>
-        <io.netty.version>4.1.121.Final</io.netty.version>
+        <io.netty.version>4.1.127.Final</io.netty.version>
         <jakarta.activation-api.javax.version>1.2.2</jakarta.activation-api.javax.version>
         <jakarta.xml.bind-api.javax.version>2.3.3</jakarta.xml.bind-api.javax.version>
         <jaxb-osgi.javax.version>2.3.9</jaxb-osgi.javax.version>


### PR DESCRIPTION
This pull request updates the `io.netty.version` property in the `pom.xml` file for the OPC UA driver provider bundle, ensuring the project uses the latest compatible Netty library.

- Dependency version update:
  * Upgraded the `io.netty.version` property from `4.1.121.Final` to `4.1.127.Final` in `bundles/org.eclipse.kura.driver.opcua.provider/pom.xml`, which brings in the latest bug fixes and improvements from the Netty project.